### PR TITLE
Lower windowLevel only when windowLevel equals UIWindowLevelStatusBar

### DIFF
--- a/ABVolumeControl/Classes/ABVolumeControl.m
+++ b/ABVolumeControl/Classes/ABVolumeControl.m
@@ -43,13 +43,17 @@
     _volumeControlStyle = volumeControlStyle;
     
     if ([self notNull:self.volumeBar]) {
-        self.volumeBar.window.windowLevel = UIWindowLevelStatusBar-1;
+        if (self.volumeBar.window.windowLevel == UIWindowLevelStatusBar) {
+            self.volumeBar.window.windowLevel--;
+        }
         [self.volumeBar removeFromSuperview];
         self.volumeBar = nil;
     }
     
     if ([self notNull:self.volumeBackground]) {
-        self.volumeBackground.window.windowLevel = UIWindowLevelStatusBar-1;
+        if (self.volumeBackground.window.windowLevel == UIWindowLevelStatusBar) {
+            self.volumeBackground.window.windowLevel--;
+        }
         [self.volumeBackground removeFromSuperview];
         self.volumeBackground = nil;
     }


### PR DESCRIPTION
windowLevels of `volumeBar` and `volumeBackground` are adjusted to `UIWindowLevelStatusBar` only when `volumeControlStyle == ABVolumeControlStyleStatusBar`, but these windowLevels are always adjusted to `UIWindowLevelStatusBar-1` when `setVolumeControlStyle:` is called, which changes windowLevel of keyWindow in styles other than `ABVolumeControlStyleStatusBar`